### PR TITLE
Bump regex to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-regex = "0.2.6"
+regex = "1.0.0"
 
 [lib]
 name = "scan_fmt"


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Tested in Fedora Rawhide
https://copr.fedorainfracloud.org/coprs/eclipseo/rav1e/package/rust-scan_fmt/