### PR TITLE
Fix for parsing floats that don't include . or e

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -367,6 +367,9 @@ fn scan_hex16(vs: &mut VecScanner, max_length: Option<usize>) {
 fn scan_float(vs: &mut VecScanner, max_length: Option<usize>) {
     vs.start_inc_limit(max_length);
     scan_dec10_nest(vs);
+    if vs.is_end() || vs.hit_inc_limit() {
+        return;
+    }
     if vs.cur() == '.' {
         if !vs.inc_limit() {
             return;
@@ -619,6 +622,13 @@ fn test_width() {
     assert_eq!(res.next().unwrap(), "fe07");
     assert_eq!(res.next().unwrap(), "1");
     assert_eq!(res.next().unwrap(), "432");
+}
+
+#[test]
+fn test_integer_for_float() {
+    let mut res = scan("1000", "{f}");
+    assert_eq!(res.next().unwrap(), "1000");
+    assert_eq!(res.next(), None);
 }
 
 #[test]


### PR DESCRIPTION
Rust allows strings of integral values to be parsed to `f32` or `f64` using the `str::parse` method. I was trying to use `scan_fmt` to parse an integral value to a floating point, but I was getting the following panic:
**Code**:
```
let res = scan_fmt::scan_fmt!("1000", "{f}");
```

**Error**:
```
thread 'parse::test_integer_for_float' panicked at 'index out of bounds: the len is 4 but the index is 4', src/parse.rs:68:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The issue had to do with `scan_dec10_nest` potentially exhausting the input, but then `scan_float` called `vs.cur()` to check for `.` or `e`, which would throw the out-of-bounds error since we were at end-of-input. The fix for this was to check if we were at end-of-input *before* doing the check for `.` or `e`.

I added a test (`test_integer_for_float`) to check for this edge case and ensured none of the other tests failed with the change.

I also manually checked the other uses of `scan_dec10_nest` (and `scan_dec10`) and it didn't seem like it was used in a location that assumed end-of-input was not reached already.


