### PR TITLE
Cargo.toml: fix CVE-2022-24713 with regex upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default = ["regex", "std"]
 std = []
 
 [dependencies]
-regex = { version = "1", optional = true }
+regex = { version = "1.6", optional = true }
 
 [lib]
 name = "scan_fmt"


### PR DESCRIPTION
Fixes CVE-2022-24713

Regexes with large repetitions on empty sub-expressions take a very long time to parse,
upgrade to newer revision to fix that

Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>